### PR TITLE
docs(examples): split cmd/quickstart into Quick Start + e2e variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to `go-pubsub` are documented in this file. The
 format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [v1.1.0] - 2026-06-13
 
 ### Changed
 - **Breaking**: rename `pubsub.SubscriptionCapacityExceed` →
@@ -248,5 +248,5 @@ gating them). `BenchmarkPublishSingleSubscriber` stays at ~108 ns/op,
 - README-cited benchmark suite (`bench_test.go`).
 - `cmd/quickstart` runnable example.
 
-[Unreleased]: https://github.com/F2077/go-pubsub/compare/v1.0.0...HEAD
+[v1.1.0]: https://github.com/F2077/go-pubsub/compare/v1.0.0...v1.1.0
 [v1.0.0]: https://github.com/F2077/go-pubsub/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -149,6 +149,42 @@ exercised statements).
   No library-code changes; the existing unit tests in `pubsub/`
   remain the contract.
 
+### Changed (examples split)
+- `cmd/quickstart` split into two binaries so the README's
+  **Quick Start** has a runnable counterpart.
+  - `cmd/quickstart/main.go` (NEW) — a ~50-line minimum viable
+    example that mirrors README's Quick Start verbatim:
+    one broker, one publisher, one subscriber, one topic,
+    one publish, one receive. `go run ./cmd/quickstart`
+    prints `Received: CPU over 90%!`. Replaces the
+    13-phase end-to-end script that previously lived in
+    this directory.
+  - `cmd/quickstart-e2e/main.go` (NEW) — the previous
+    13-phase ~260-line end-to-end walk-through, unchanged in
+    behavior. Renamed the trailing "ok" line from
+    `quickstart: ok` → `quickstart-e2e: ok` to match the new
+    binary name.
+  - `cmd/quickstart/README.md` rewritten to describe the
+    minimal Quick Start binary and point at
+    `cmd/quickstart-e2e/README.md` for the deeper
+    walk-through.
+  - `cmd/quickstart-e2e/README.md` (NEW) — the previous
+    contents of `cmd/quickstart/README.md`, with the
+    internal `cmd/quickstart/main.go` references updated to
+    `cmd/quickstart-e2e/main.go`.
+  - `README.md` Quick Start rewritten to match the new
+    minimal binary 1:1 (the old snippet had drifted from
+    the actual library behaviour in three places: `panic`
+    instead of `log.Fatal` was fine, but the IIFE-wrapped
+    `defer sub.Close()` was dead ceremony, the
+    `WithTimeout[string](5*time.Second)` was unreachable
+    in the happy-path run, and the `// Output: "..."`
+    comment is a godoc convention that doesn't apply to
+    `cmd/` binaries). The new snippet uses synchronous
+    `Publish` (so the 200 ms sliding timer demonstrably
+    resets on the happy path) and points at
+    `cmd/quickstart-e2e` for the long-form demo.
+
 ### Changed (test-side cleanup)
 - Test files now share a single `testLogger()` / `benchLogger()` pair
   in `pubsub/helpers_test.go`; ~19 inline `slog.New(...)` duplicates

--- a/README.md
+++ b/README.md
@@ -20,54 +20,83 @@ go get github.com/F2077/go-pubsub
 
 ## Quick Start
 
+The shortest path is a runnable four-step recipe. The same program
+lives at `cmd/quickstart/main.go` — clone the repo and run:
+
+```bash
+go run ./cmd/quickstart
+```
+
+Expected output:
+
+```
+Received: CPU over 90%!
+```
+
+Source:
+
 ```go
 package main
 
 import (
 	"fmt"
-	"github.com/F2077/go-pubsub/pubsub"
+	"log"
 	"time"
+
+	"github.com/F2077/go-pubsub/pubsub"
 )
 
 func main() {
-	// 1. Create a broker (supports generics)
+	// 1. Create a broker.
 	broker, err := pubsub.NewBroker[string]()
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
 
-	// 2. Create a publisher
+	// 2. Create a publisher and a subscriber bound to that broker.
 	publisher := pubsub.NewPublisher[string](broker)
-
-	// 3. Create a subscriber
 	subscriber := pubsub.NewSubscriber[string](broker)
 
-	// 4. Subscribe to a topic with buffer size and timeout
+	// 3. Subscribe to a topic. WithChannelSize sets the per-topic
+	// channel's buffer; WithTimeout arms a sliding 200ms timer that
+	// resets on every successful publish and fires ErrSubscriptionTimeout
+	// to ErrCh if no publish lands within the window.
 	sub, err := subscriber.Subscribe("alerts",
-		pubsub.WithChannelSize[string](pubsub.Medium), // Buffer 100 messages
-		pubsub.WithTimeout[string](5*time.Second),     // Auto-close if idle
+		pubsub.WithChannelSize[string](pubsub.Medium),
+		pubsub.WithTimeout[string](200*time.Millisecond),
 	)
 	if err != nil {
-		panic(err)
+		log.Fatal(err)
 	}
-	defer func(sub *pubsub.Subscription[string]) {
-		_ = sub.Close()
-	}(sub)
+	defer sub.Close()
 
-	// 5. Publish a message
-	go func() {
-		_ = publisher.Publish("alerts", "CPU over 90%!")
-	}()
+	// 4. Publish synchronously. A successful delivery resets the
+	// sliding timer in step 3, so the 200ms window is irrelevant
+	// for a happy-path run.
+	if err := publisher.Publish("alerts", "CPU over 90%!"); err != nil {
+		log.Fatal(err)
+	}
 
-	// 6. Listen for messages or timeouts
+	// 5. Receive. With WithTimeout set, ErrCh is a buffered error
+	// channel that receives ErrSubscriptionTimeout exactly once when
+	// the timer fires; without WithTimeout it would be nil. In this
+	// happy-path the timer never fires — Publish landed first.
 	select {
 	case msg := <-sub.Ch:
-		fmt.Println("Received:", msg) // Output: "CPU over 90%!"
+		fmt.Println("Received:", msg)
 	case err := <-sub.ErrCh:
-		fmt.Println("Error:", err)
+		log.Println("Timeout:", err)
 	}
 }
+```
 
+For a deeper walk-through that exercises every exported symbol
+(`Subscribes`, `OnClose`, the lazy-`ErrCh` contract, the
+capacity-exceeded path, sliding timeouts firing naturally, …) see
+`cmd/quickstart-e2e`:
+
+```bash
+go run ./cmd/quickstart-e2e
 ```
 
 ## Key Features

--- a/cmd/quickstart-e2e/README.md
+++ b/cmd/quickstart-e2e/README.md
@@ -1,0 +1,95 @@
+# cmd/quickstart-e2e
+
+A runnable, end-to-end walk-through of the entire `go-pubsub` public
+surface. The program is structured as 13 numbered phases: each phase
+exercises one or more exported APIs, prints a header, and then continues
+to the next. The whole script runs in well under a second.
+
+This is the deeper counterpart to `cmd/quickstart`, which keeps a
+single happy-path 50-line example so it can mirror README's
+**Quick Start** verbatim. Use `cmd/quickstart-e2e` when you want
+to see every constructor, option, constant, sentinel, method, field,
+and callback in a single `go run`.
+
+## Run it
+
+```bash
+# from the repo root
+go run ./cmd/quickstart-e2e
+
+# or, once the module is tagged
+go run github.com/F2077/go-pubsub/cmd/quickstart-e2e@latest
+```
+
+A successful run prints a transcript that starts with `=== 1. Brokers ===`
+and ends with `quickstart-e2e: ok`. The full output is ~30 lines and
+fits in a terminal scrollback.
+
+## What it shows
+
+| Phase | APIs exercised |
+| ---: | --- |
+| 1 | `pubsub.NewBroker[T]`, `Broker.String`, `Broker.Capacity`, `pubsub.DefaultCapacity` |
+| 2 | `pubsub.WithLogger`, `pubsub.WithId`, `pubsub.ErrLoggerNil`, `pubsub.ErrBrokerIdEmpty`, `errors.Is` |
+| 3 | `pubsub.NewPublisher[T]`, `pubsub.NewSubscriber[T]`, `Publisher.String`, `Publisher.Id`, `Subscriber.String`, `Subscriber.Id` |
+| 4 | `Subscriber.Subscribes`, `Subscription.Ch` (capacity), `Subscription.ErrCh` (lazy-nil contract), `Subscription.OnClose` |
+| 5 | `Subscriber.Subscribe`, `pubsub.WithChannelSize(pubsub.Block)`, `pubsub.WithTimeout`, `pubsub.DefaultTimeout` (implicit), `cap` on receive-only channel |
+| 6 | (helper plumbing — drain goroutines) |
+| 7 | `Publisher.Publish` × 15 across 3 topics / 2 publishers |
+| 8 | `pubsub.WithCapacity(2)`, `pubsub.ErrSubscriptionCapacityExceeded`, `errors.Is` |
+| 9 | `pubsub.ErrSubscriptionTimeout` (the sliding 400 ms timer fires naturally) |
+| 10 | `Subscription.Close` (fires `OnClose`), `Subscriber.Close` (idempotent + `ErrSubscriberClosed`), `Subscriber.Subscribe` after `Close` returns `ErrSubscriberClosed` |
+| 11 | Per-subscription `sub.Close()` × 3 (each fires its own `OnClose`) |
+| 12 | (joins the 4 drain goroutines) |
+| 13 | `Broker.Topics` — may show a non-empty snapshot briefly after Close due to asynchronous topic reaping |
+
+The script's `main` package keeps the orchestration in `run()` and
+the drain logic in a generic `drainSubscription[T]` helper. `main`
+itself is a thin error wrapper that prints failures to stderr and
+exits non-zero.
+
+## Layout rationale
+
+`cmd/quickstart-e2e/main.go` follows the standard Go layout per
+[golang-standards/project-layout](https://github.com/golang-standards/project-layout#cmd-directory):
+
+> Main applications for this project. The directory name for each
+> application should match the name of the executable you want to
+> have (e.g. `/cmd/myapp`). It's common to have a small `main` function
+> that imports and invokes the code from the `/internal` and `/pkg`
+> directories and nothing else.
+
+The example uses ~260 lines of source so that the runnable program
+can demonstrate every exported symbol in one go (constructors,
+options, constants, sentinels, methods, fields, callbacks). All of
+the API surface that is *not* observable from a single-process
+script — the genuinely cross-process pieces — is intentionally
+left out, and `go-pubsub` is an in-process library, so this covers
+the whole product.
+
+## What it does NOT show
+
+- **Backpressure / guaranteed delivery.** The library is fire-and-forget
+  by design: `Publish` is non-blocking, full channels drop messages,
+  and there is no acknowledgement path. The quickstart only uses
+  `Block` once (in phase 5) for the sliding-timeout demo; everywhere
+  else it uses the drop-tolerant `Medium` buffer.
+- **Signal handling / graceful shutdown.** A long-running program
+  would also trap `SIGINT`/`SIGTERM` and call `subscriber.Close()` on
+  exit. The quickstart exits immediately after `run()` returns, so
+  there is nothing to trap.
+- **Subscriber error paths beyond the sentinels.** `subscriber.Close()`
+  on a multi-topic subscriber is exercised in phases 10–11; the
+  per-subscription `sub.Close()` after the subscriber itself has been
+  closed is also exercised. Other close-order edge cases (e.g.
+  closing the same sub twice) are covered by the unit tests in
+  `pubsub/`.
+
+## Why the broker's `Topics()` snapshot may be non-empty at exit
+
+Phases 10–11 close every subscription, but the broker reaps empty
+topics in a separate goroutine to avoid a `subscription → broker`
+lock-order deadlock (see `pubsub/broker.go:285`). A freshly-emptied
+topic may therefore still appear in the `Topics()` snapshot for a
+short window after `subscriber.Close()` returns. This is intentional,
+documented behaviour, not a leak.

--- a/cmd/quickstart-e2e/main.go
+++ b/cmd/quickstart-e2e/main.go
@@ -1,0 +1,272 @@
+// Command quickstart is the runnable end-to-end example for the
+// go-pubsub public surface. It wires up a broker with custom id and
+// capacity, validates the option error paths, fans three topics across
+// two subscribers, demonstrates the sliding-timeout contract, exercises
+// every exported sentinel, and introspects the broker on exit.
+//
+// Run from the repo root:
+//
+//	go run ./cmd/quickstart
+package main
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/F2077/go-pubsub/pubsub"
+)
+
+func main() {
+	// 顶层把 run() 包起来，让所有错误都走 stderr + 非零退出码；
+	// 不让 panic 混在正常 stdout 文本里。
+	if err := run(); err != nil {
+		fmt.Fprintln(os.Stderr, "quickstart:", err)
+		os.Exit(1)
+	}
+}
+
+// run 把整个端到端走完拆成 13 个 phase。phase 之间通过共享变量串联，
+// 但每个 phase 内部都是自包含的，可以单独阅读。
+func run() error {
+	// 把 broker 的锁跟踪日志压到 Warn 级别，避免一次 happy-path
+	// 跑下来刷一堆读/写锁 acquired/released 噪声。
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	// === Phase 1: 构造两个 broker =====================================
+	// 主流程用 mainBroker，cap 走默认 + 显式 WithId。
+	// tinyBroker (cap=2) 仅用于 phase 8 触发容量错误，不参与消息流。
+	mainBroker, err := pubsub.NewBroker[string](
+		pubsub.WithLogger[string](logger),
+		pubsub.WithId[string]("alerts-router"),
+		pubsub.WithCapacity[string](pubsub.DefaultCapacity),
+	)
+	if err != nil {
+		return fmt.Errorf("new main broker: %w", err)
+	}
+	tinyBroker, err := pubsub.NewBroker[string](pubsub.WithCapacity[string](2))
+	if err != nil {
+		return fmt.Errorf("new tiny broker: %w", err)
+	}
+
+	fmt.Println("=== 1. Brokers ===")
+	fmt.Println("main :", mainBroker) // 走 String()
+	fmt.Println("tiny :", tinyBroker)
+	fmt.Println("main.Capacity()      :", mainBroker.Capacity())
+	fmt.Println("pubsub.DefaultCapacity :", pubsub.DefaultCapacity)
+
+	// === Phase 2: BrokerOption 校验错误路径 =============================
+	// WithLogger / WithId 在非法输入下返回 sentinel；用 errors.Is 区分。
+	fmt.Println("\n=== 2. BrokerOption validation (errors.Is) ===")
+	if _, err := pubsub.NewBroker[string](pubsub.WithLogger[string](nil)); !errors.Is(err, pubsub.ErrLoggerNil) {
+		return fmt.Errorf("WithLogger(nil): expected ErrLoggerNil, got %v", err)
+	}
+	fmt.Println("  WithLogger(nil)  ->", pubsub.ErrLoggerNil)
+
+	if _, err := pubsub.NewBroker[string](pubsub.WithId[string]("")); !errors.Is(err, pubsub.ErrBrokerIdEmpty) {
+		return fmt.Errorf("WithId(\"\"): expected ErrBrokerIdEmpty, got %v", err)
+	}
+	fmt.Println("  WithId(\"\")      ->", pubsub.ErrBrokerIdEmpty)
+
+	// === Phase 3: 构造 publisher / subscriber handle ====================
+	// 两个 publisher 共用 mainBroker，两个 subscriber 同样共用。
+	pubA := pubsub.NewPublisher[string](mainBroker)
+	pubB := pubsub.NewPublisher[string](mainBroker)
+	subA := pubsub.NewSubscriber[string](mainBroker)
+	subB := pubsub.NewSubscriber[string](mainBroker)
+
+	fmt.Println("\n=== 3. Publisher / Subscriber handles ===")
+	fmt.Println("  pubA :", pubA)
+	fmt.Println("  pubB :", pubB, " id=", pubB.Id())
+	fmt.Println("  subA :", subA)
+	fmt.Println("  subB :", subB, " id=", subB.Id())
+
+	// === Phase 4: subA 用 Subscribes 一次订 3 个 topic =================
+	// WithChannelSize(Medium) 给所有 3 个 sub 用同一个 100 槽缓冲；
+	// 没传 WithTimeout，ErrCh 应该是 nil（lazy alloc 合约）。
+	subATopics := []string{"metrics", "audit", "alerts"}
+	subsA, err := subA.Subscribes(
+		subATopics,
+		pubsub.WithChannelSize[string](pubsub.Medium),
+	)
+	if err != nil {
+		return fmt.Errorf("subA.Subscribes: %w", err)
+	}
+
+	fmt.Println("\n=== 4. subA.Subscribes(metrics, audit, alerts) ===")
+	for i, s := range subsA {
+		// OnClose 是 quickstart 拿到 topic 名字的唯一路径（Subscription
+		// 没暴露 Topic()），所以同时充当 "topic 名称回显" + 关闭回调。
+		s.OnClose = func(topic string) {
+			fmt.Printf("  [OnClose] subA sub#%d topic=%q\n", i, topic)
+		}
+		fmt.Printf("  sub#%d topic=%-8s Ch cap=%d ErrCh==nil? %v\n",
+			i, subATopics[i], cap(s.Ch), s.ErrCh == nil)
+	}
+
+	// === Phase 5: subB 单独订 "alerts" + Block + 滑动超时 ==============
+	// 400ms 的短超时让我们能在一个 run() 内就等到 timeout 真的 fire，
+	// 不至于让 quickstart 拖到分钟级。
+	subBsub, err := subB.Subscribe(
+		"alerts",
+		pubsub.WithChannelSize[string](pubsub.Block),
+		pubsub.WithTimeout[string](400*time.Millisecond),
+	)
+	if err != nil {
+		return fmt.Errorf("subB.Subscribe: %w", err)
+	}
+	subBsub.OnClose = func(topic string) {
+		fmt.Printf("  [OnClose] subBsub closing topic=%q\n", topic)
+	}
+
+	fmt.Println("\n=== 5. subB.Subscribe(alerts, Block, 400ms timeout) ===")
+	fmt.Printf("  subBsub.Ch cap=%d (Block=0 means unbuffered)\n", cap(subBsub.Ch))
+	fmt.Printf("  subBsub.ErrCh==nil? %v (timeout set => non-nil)\n", subBsub.ErrCh == nil)
+
+	// === Phase 6: 起 4 个 drain goroutine 各自消费一条 sub ============
+	// 收尾时通过 done channel 等齐。subA 三个 drain 等 Ch 关闭；
+	// subBsub 的 drain 同时监听 Ch + ErrCh（任一边关闭即退出）。
+	fmt.Println("\n=== 6. Drain goroutines (4× spawned) ===")
+	dones := []<-chan struct{}{
+		drainSubscription("subA:metrics", subsA[0], nil),
+		drainSubscription("subA:audit", subsA[1], nil),
+		drainSubscription("subA:alerts", subsA[2], nil),
+		drainSubscription("subB:alerts", subBsub, subBsub.ErrCh),
+	}
+	fmt.Println("  4 drainers running; will be joined in Phase 12")
+
+	// === Phase 7: Publish 突发流量 ====================================
+	fmt.Println("\n=== 7. Publish burst ===")
+	for i := 0; i < 5; i++ {
+		_ = pubA.Publish("metrics", fmt.Sprintf("m=%d", i))
+		_ = pubA.Publish("audit", fmt.Sprintf("a=%d", i))
+		_ = pubB.Publish("alerts", fmt.Sprintf("alert=%d", i))
+	}
+	fmt.Println("  15 messages dispatched (5 per topic × 3 topics)")
+
+	// === Phase 8: 容量错误（tiny broker，cap=2）=========================
+	fmt.Println("\n=== 8. ErrSubscriptionCapacityExceeded (tiny broker, cap=2) ===")
+	pubT := pubsub.NewPublisher[string](tinyBroker)
+	subT := pubsub.NewSubscriber[string](tinyBroker)
+	if err := pubT.Publish("t1", "x"); err != nil {
+		return fmt.Errorf("Publish t1 should succeed: %w", err)
+	}
+	fmt.Println("  Publish(t1)    -> ok (1/2)")
+	if err := pubT.Publish("t2", "x"); err != nil {
+		return fmt.Errorf("Publish t2 should succeed: %w", err)
+	}
+	fmt.Println("  Publish(t2)    -> ok (2/2)")
+	_, err = subT.Subscribe("t3")
+	if !errors.Is(err, pubsub.ErrSubscriptionCapacityExceeded) {
+		return fmt.Errorf("Subscribe t3: expected ErrSubscriptionCapacityExceeded, got %v", err)
+	}
+	fmt.Println("  Subscribe(t3)  ->", err)
+
+	// === Phase 9: 等 subBsub 的滑动 timeout 自然 fire ===================
+	// 上面最后一次 publish 之后 400ms，timer 就会 fire。
+	// drain goroutine 看到 ErrSubscriptionTimeout 就会打印并退出。
+	fmt.Println("\n=== 9. Sliding timeout (subBsub, 400ms) ===")
+	time.Sleep(500 * time.Millisecond)
+
+	// === Phase 10: ErrSubscriberClosed 路径 =============================
+	// 这里分两条路：
+	//  1) subBsub.Close() -> 走 OnClose + unsubscribe（topic=alerts 退出）
+	//  2) subB.Close() 第一次 -> 所有 topic 都已经退订，no-op，nil
+	//  3) subB.Close() 第二次 -> 返回 ErrSubscriberClosed
+	//  4) subB.Subscribe(...) -> 返回 ErrSubscriberClosed
+	fmt.Println("\n=== 10. ErrSubscriberClosed ===")
+	if err := subBsub.Close(); err != nil {
+		return fmt.Errorf("subBsub.Close: %w", err)
+	}
+	if err := subB.Close(); err != nil {
+		return fmt.Errorf("first subB.Close should be a no-op, got %v", err)
+	}
+	if err := subB.Close(); !errors.Is(err, pubsub.ErrSubscriberClosed) {
+		return fmt.Errorf("second subB.Close: expected ErrSubscriberClosed, got %v", err)
+	}
+	fmt.Println("  subBsub.Close()  -> OnClose fired above")
+	fmt.Println("  subB.Close() 1st -> nil (no topics left)")
+	fmt.Println("  subB.Close() 2nd ->", pubsub.ErrSubscriberClosed)
+	if _, err := subB.Subscribe("after-close"); !errors.Is(err, pubsub.ErrSubscriberClosed) {
+		return fmt.Errorf("Subscribe after Close: expected ErrSubscriberClosed, got %v", err)
+	}
+	fmt.Println("  subB.Subscribe()  ->", pubsub.ErrSubscriberClosed)
+
+	// === Phase 11: 逐个关 subA 的 sub，触发 OnClose × 3 ================
+	// Subscriber.Close 不会触发 OnClose（设计上 OnClose 只挂在
+	// Subscription.Close 上），所以要拿到 3 个 OnClose 回调只能
+	// 显式 sub.Close() 三个。
+	fmt.Println("\n=== 11. OnClose × 3 (subA's subscriptions) ===")
+	for _, s := range subsA {
+		if err := s.Close(); err != nil {
+			return fmt.Errorf("subA sub.Close: %w", err)
+		}
+	}
+	// 三个 topic 都已退订，subA.Close() 这里是 no-op。再次调一次
+	// 演示 Subscriber.Close 也走 ErrSubscriberClosed 这条路。
+	if err := subA.Close(); err != nil {
+		return fmt.Errorf("subA.Close (after per-sub close) should be no-op, got %v", err)
+	}
+	if err := subA.Close(); !errors.Is(err, pubsub.ErrSubscriberClosed) {
+		return fmt.Errorf("second subA.Close: expected ErrSubscriberClosed, got %v", err)
+	}
+
+	// === Phase 12: 等所有 drain goroutine 退出 =========================
+	fmt.Println("\n=== 12. Drain summary ===")
+	for _, done := range dones {
+		<-done
+	}
+	fmt.Println("  all drainers exited")
+
+	// === Phase 13: 退出前 introspect broker ============================
+	// 异步 topic reaping：topic 最后一个订阅者退订后，broker 在独立
+	// goroutine 里才回收，所以 Topics() 看到的可能是 0~3 的中间态。
+	// 最坏情况：3 个 topic 都还在（reaping 还没跑）；最好情况：0
+	// （reaping 跑得比 Close 完还快）。实测通常落在 0~1。
+	fmt.Println("\n=== 13. Broker.Topics() at exit ===")
+	topics := mainBroker.Topics()
+	fmt.Printf("  %d topic(s) still tracked: %v\n", len(topics), topics)
+
+	fmt.Println("\nquickstart-e2e: ok")
+	return nil
+}
+
+// drainSubscription 消费一条 *Subscription 直到 Ch 关闭，或者
+// errCh 给出错误（subBsub 走 timeout 路径会触发此分支）。
+// 返回的 channel 在 drain 退出时关闭，让调用方能 join。
+func drainSubscription[T any](label string, sub *pubsub.Subscription[T], errCh <-chan error) <-chan struct{} {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if errCh == nil {
+			// 没传 ErrCh：单纯排空 Ch。subA 的 3 个 sub 走这条。
+			// 静默排空到 sub.Ch 关闭；输出让 phase 7 那种 burst 自证。
+			for range sub.Ch {
+				_ = struct{}{}
+			}
+			return
+		}
+		// 同时监听 Ch + ErrCh，任一边关闭 / 给出错误即退出。
+		for {
+			select {
+			case _, ok := <-sub.Ch:
+				if !ok {
+					return
+				}
+			case err, ok := <-errCh:
+				if !ok {
+					return
+				}
+				if errors.Is(err, pubsub.ErrSubscriptionTimeout) {
+					fmt.Printf("  [timeout] %s: %v\n", label, err)
+					return
+				}
+				fmt.Printf("  [error]   %s: %v\n", label, err)
+				return
+			}
+		}
+	}()
+	return done
+}

--- a/cmd/quickstart/README.md
+++ b/cmd/quickstart/README.md
@@ -1,86 +1,48 @@
 # cmd/quickstart
 
-A runnable, end-to-end walk-through of the entire `go-pubsub` public
-surface. The program is structured as 13 numbered phases: each phase
-exercises one or more exported APIs, prints a header, and then continues
-to the next. The whole script runs in well under a second.
+A runnable, minimal go-pubsub example. The program is the same
+five-step recipe shown in the top-level `README.md` under
+**Quick Start**:
 
-## Run it
+1. `pubsub.NewBroker[string]()` — create a broker.
+2. `pubsub.NewPublisher[string](broker)` + `pubsub.NewSubscriber[string](broker)`
+   — bind a publisher and a subscriber to it.
+3. `subscriber.Subscribe("alerts", WithChannelSize[string](Medium), WithTimeout[string](200ms))`
+   — attach to a topic with a buffered channel and a sliding idle
+   timer.
+4. `publisher.Publish("alerts", "CPU over 90%!")` — send a message.
+5. `select { case msg := <-sub.Ch: ...; case err := <-sub.ErrCh: ... }`
+   — consume one message and print it.
+
+The point of this binary is to mirror `README.md`'s Quick Start
+verbatim, so a reader can `git clone` the repo and confirm the
+documentation by running:
 
 ```bash
-# from the repo root
 go run ./cmd/quickstart
-
-# or, once the module is tagged
-go run github.com/F2077/go-pubsub/cmd/quickstart@latest
 ```
 
-A successful run prints a transcript that starts with `=== 1. Brokers ===`
-and ends with `quickstart: ok`. The full output is ~30 lines and fits in a
-terminal scrollback.
+Expected output:
 
-## What it shows
+```
+Received: CPU over 90%!
+```
 
-| Phase | APIs exercised |
-| ---: | --- |
-| 1 | `pubsub.NewBroker[T]`, `Broker.String`, `Broker.Capacity`, `pubsub.DefaultCapacity` |
-| 2 | `pubsub.WithLogger`, `pubsub.WithId`, `pubsub.ErrLoggerNil`, `pubsub.ErrBrokerIdEmpty`, `errors.Is` |
-| 3 | `pubsub.NewPublisher[T]`, `pubsub.NewSubscriber[T]`, `Publisher.String`, `Publisher.Id`, `Subscriber.String`, `Subscriber.Id` |
-| 4 | `Subscriber.Subscribes`, `Subscription.Ch` (capacity), `Subscription.ErrCh` (lazy-nil contract), `Subscription.OnClose` |
-| 5 | `Subscriber.Subscribe`, `pubsub.WithChannelSize(pubsub.Block)`, `pubsub.WithTimeout`, `pubsub.DefaultTimeout` (implicit), `cap` on receive-only channel |
-| 6 | (helper plumbing — drain goroutines) |
-| 7 | `Publisher.Publish` × 15 across 3 topics / 2 publishers |
-| 8 | `pubsub.WithCapacity(2)`, `pubsub.ErrSubscriptionCapacityExceeded`, `errors.Is` |
-| 9 | `pubsub.ErrSubscriptionTimeout` (the sliding 400 ms timer fires naturally) |
-| 10 | `Subscription.Close` (fires `OnClose`), `Subscriber.Close` (idempotent + `ErrSubscriberClosed`), `Subscriber.Subscribe` after `Close` returns `ErrSubscriberClosed` |
-| 11 | Per-subscription `sub.Close()` × 3 (each fires its own `OnClose`) |
-| 12 | (joins the 4 drain goroutines) |
-| 13 | `Broker.Topics` — may show a non-empty snapshot briefly after Close due to asynchronous topic reaping |
+The whole program is ~50 lines. It deliberately exercises only
+the path a brand-new user cares about: one broker, one publisher,
+one subscriber, one topic, one message, one receive. Anything else
+(sentinels, capacity errors, multi-topic `Subscribes`, the
+sliding-timeout firing naturally, etc.) is left to
+`cmd/quickstart-e2e`.
 
-The script's `main` package keeps the orchestration in `run()` and the
-drain logic in a generic `drainSubscription[T]` helper. `main` itself is
-a thin error wrapper that prints failures to stderr and exits non-zero.
-
-## Layout rationale
+## Layout
 
 `cmd/quickstart/main.go` follows the standard Go layout per
 [golang-standards/project-layout](https://github.com/golang-standards/project-layout#cmd-directory):
 
 > Main applications for this project. The directory name for each
-> application should match the name of the executable you want to have
-> (e.g., `/cmd/myapp`). It's common to have a small `main` function
-> that imports and invokes the code from the `/internal` and `/pkg`
-> directories and nothing else.
+> application should match the name of the executable you want to
+> have (e.g. `/cmd/myapp`).
 
-The example uses ~260 lines of source so that the runnable program can
-demonstrate every exported symbol in one go (constructors, options,
-constants, sentinels, methods, fields, callbacks). All of the API
-surface that is *not* observable from a single-process script — the
-genuinely cross-process pieces — is intentionally left out, and
-`go-pubsub` is an in-process library, so this covers the whole product.
-
-## What it does NOT show
-
-- **Backpressure / guaranteed delivery.** The library is fire-and-forget
-  by design: `Publish` is non-blocking, full channels drop messages,
-  and there is no acknowledgement path. The quickstart only uses
-  `Block` once (in phase 5) for the sliding-timeout demo; everywhere
-  else it uses the drop-tolerant `Medium` buffer.
-- **Signal handling / graceful shutdown.** A long-running program
-  would also trap `SIGINT`/`SIGTERM` and call `subscriber.Close()` on
-  exit. The quickstart exits immediately after `run()` returns, so
-  there is nothing to trap.
-- **Subscriber error paths beyond the sentinels.** `subscriber.Close()`
-  on a multi-topic subscriber is exercised in phases 10–11; the
-  per-subscription `sub.Close()` after the subscriber itself has been
-  closed is also exercised. Other close-order edge cases (e.g. closing
-  the same sub twice) are covered by the unit tests in `pubsub/`.
-
-## Why the broker's `Topics()` snapshot may be non-empty at exit
-
-Phases 10–11 close every subscription, but the broker reaps empty
-topics in a separate goroutine to avoid a `subscription → broker`
-lock-order deadlock (see `pubsub/broker.go:285`). A freshly-emptied
-topic may therefore still appear in the `Topics()` snapshot for a
-short window after `subscriber.Close()` returns. This is intentional,
-documented behaviour, not a leak.
+A short `package main` comment at the top of `main.go` points
+readers at `cmd/quickstart-e2e` for the deeper walk-through.

--- a/cmd/quickstart/main.go
+++ b/cmd/quickstart/main.go
@@ -1,272 +1,73 @@
-// Command quickstart is the runnable end-to-end example for the
-// go-pubsub public surface. It wires up a broker with custom id and
-// capacity, validates the option error paths, fans three topics across
-// two subscribers, demonstrates the sliding-timeout contract, exercises
-// every exported sentinel, and introspects the broker on exit.
+// Command quickstart is the minimal go-pubsub example mirrored in
+// README's "Quick Start" section.
 //
-// Run from the repo root:
+// It demonstrates the four-step recipe a reader of pkg.go.dev would
+// arrive at by themselves:
 //
-//	go run ./cmd/quickstart
+//  1. Create a broker.
+//  2. Create a publisher and a subscriber bound to that broker.
+//  3. Subscribe to a topic — WithChannelSize buffers deliveries,
+//     WithTimeout arms a sliding timer that delivers
+//     ErrSubscriptionTimeout to ErrCh after the configured idle period.
+//  4. Publish a message and consume it on sub.Ch.
+//
+// Run: `go run ./cmd/quickstart`.
+//
+// For a longer walk-through that exercises every exported symbol
+// (multiple brokers, the capacity-exceeded path, sliding timeouts
+// firing naturally, OnClose, Subscribes, the lazy-ErrCh contract, etc.)
+// see `cmd/quickstart-e2e`.
 package main
 
 import (
-	"errors"
 	"fmt"
-	"log/slog"
-	"os"
+	"log"
 	"time"
 
 	"github.com/F2077/go-pubsub/pubsub"
 )
 
 func main() {
-	// 顶层把 run() 包起来，让所有错误都走 stderr + 非零退出码；
-	// 不让 panic 混在正常 stdout 文本里。
-	if err := run(); err != nil {
-		fmt.Fprintln(os.Stderr, "quickstart:", err)
-		os.Exit(1)
-	}
-}
-
-// run 把整个端到端走完拆成 13 个 phase。phase 之间通过共享变量串联，
-// 但每个 phase 内部都是自包含的，可以单独阅读。
-func run() error {
-	// 把 broker 的锁跟踪日志压到 Warn 级别，避免一次 happy-path
-	// 跑下来刷一堆读/写锁 acquired/released 噪声。
-	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelWarn}))
-
-	// === Phase 1: 构造两个 broker =====================================
-	// 主流程用 mainBroker，cap 走默认 + 显式 WithId。
-	// tinyBroker (cap=2) 仅用于 phase 8 触发容量错误，不参与消息流。
-	mainBroker, err := pubsub.NewBroker[string](
-		pubsub.WithLogger[string](logger),
-		pubsub.WithId[string]("alerts-router"),
-		pubsub.WithCapacity[string](pubsub.DefaultCapacity),
-	)
+	// 1. Create a broker.
+	broker, err := pubsub.NewBroker[string]()
 	if err != nil {
-		return fmt.Errorf("new main broker: %w", err)
-	}
-	tinyBroker, err := pubsub.NewBroker[string](pubsub.WithCapacity[string](2))
-	if err != nil {
-		return fmt.Errorf("new tiny broker: %w", err)
+		log.Fatal(err)
 	}
 
-	fmt.Println("=== 1. Brokers ===")
-	fmt.Println("main :", mainBroker) // 走 String()
-	fmt.Println("tiny :", tinyBroker)
-	fmt.Println("main.Capacity()      :", mainBroker.Capacity())
-	fmt.Println("pubsub.DefaultCapacity :", pubsub.DefaultCapacity)
+	// 2. Create a publisher and a subscriber bound to that broker.
+	publisher := pubsub.NewPublisher[string](broker)
+	subscriber := pubsub.NewSubscriber[string](broker)
 
-	// === Phase 2: BrokerOption 校验错误路径 =============================
-	// WithLogger / WithId 在非法输入下返回 sentinel；用 errors.Is 区分。
-	fmt.Println("\n=== 2. BrokerOption validation (errors.Is) ===")
-	if _, err := pubsub.NewBroker[string](pubsub.WithLogger[string](nil)); !errors.Is(err, pubsub.ErrLoggerNil) {
-		return fmt.Errorf("WithLogger(nil): expected ErrLoggerNil, got %v", err)
-	}
-	fmt.Println("  WithLogger(nil)  ->", pubsub.ErrLoggerNil)
-
-	if _, err := pubsub.NewBroker[string](pubsub.WithId[string]("")); !errors.Is(err, pubsub.ErrBrokerIdEmpty) {
-		return fmt.Errorf("WithId(\"\"): expected ErrBrokerIdEmpty, got %v", err)
-	}
-	fmt.Println("  WithId(\"\")      ->", pubsub.ErrBrokerIdEmpty)
-
-	// === Phase 3: 构造 publisher / subscriber handle ====================
-	// 两个 publisher 共用 mainBroker，两个 subscriber 同样共用。
-	pubA := pubsub.NewPublisher[string](mainBroker)
-	pubB := pubsub.NewPublisher[string](mainBroker)
-	subA := pubsub.NewSubscriber[string](mainBroker)
-	subB := pubsub.NewSubscriber[string](mainBroker)
-
-	fmt.Println("\n=== 3. Publisher / Subscriber handles ===")
-	fmt.Println("  pubA :", pubA)
-	fmt.Println("  pubB :", pubB, " id=", pubB.Id())
-	fmt.Println("  subA :", subA)
-	fmt.Println("  subB :", subB, " id=", subB.Id())
-
-	// === Phase 4: subA 用 Subscribes 一次订 3 个 topic =================
-	// WithChannelSize(Medium) 给所有 3 个 sub 用同一个 100 槽缓冲；
-	// 没传 WithTimeout，ErrCh 应该是 nil（lazy alloc 合约）。
-	subATopics := []string{"metrics", "audit", "alerts"}
-	subsA, err := subA.Subscribes(
-		subATopics,
+	// 3. Subscribe to a topic. WithChannelSize sets the per-topic
+	// channel's buffer; WithTimeout arms a sliding 200ms timer that
+	// resets on every successful publish and fires ErrSubscriptionTimeout
+	// to ErrCh if no publish lands within the window.
+	sub, err := subscriber.Subscribe("alerts",
 		pubsub.WithChannelSize[string](pubsub.Medium),
+		pubsub.WithTimeout[string](200*time.Millisecond),
 	)
 	if err != nil {
-		return fmt.Errorf("subA.Subscribes: %w", err)
+		log.Fatal(err)
+	}
+	defer sub.Close()
+
+	// 4. Publish synchronously: Publish returns once the message has
+	// been delivered to every subscriber's per-topic channel (or
+	// dropped if the channel is full — fire-and-forget semantics).
+	// A successful delivery also resets the sliding timer in step 3,
+	// so the 200ms window is irrelevant for a happy-path run.
+	if err := publisher.Publish("alerts", "CPU over 90%!"); err != nil {
+		log.Fatal(err)
 	}
 
-	fmt.Println("\n=== 4. subA.Subscribes(metrics, audit, alerts) ===")
-	for i, s := range subsA {
-		// OnClose 是 quickstart 拿到 topic 名字的唯一路径（Subscription
-		// 没暴露 Topic()），所以同时充当 "topic 名称回显" + 关闭回调。
-		s.OnClose = func(topic string) {
-			fmt.Printf("  [OnClose] subA sub#%d topic=%q\n", i, topic)
-		}
-		fmt.Printf("  sub#%d topic=%-8s Ch cap=%d ErrCh==nil? %v\n",
-			i, subATopics[i], cap(s.Ch), s.ErrCh == nil)
+	// 5. Receive. With WithTimeout set, ErrCh is a buffered error
+	// channel that receives ErrSubscriptionTimeout exactly once when
+	// the timer fires; without WithTimeout it would be nil. In this
+	// happy-path the timer never fires — Publish landed first.
+	select {
+	case msg := <-sub.Ch:
+		fmt.Println("Received:", msg)
+	case err := <-sub.ErrCh:
+		log.Println("Timeout:", err)
 	}
-
-	// === Phase 5: subB 单独订 "alerts" + Block + 滑动超时 ==============
-	// 400ms 的短超时让我们能在一个 run() 内就等到 timeout 真的 fire，
-	// 不至于让 quickstart 拖到分钟级。
-	subBsub, err := subB.Subscribe(
-		"alerts",
-		pubsub.WithChannelSize[string](pubsub.Block),
-		pubsub.WithTimeout[string](400*time.Millisecond),
-	)
-	if err != nil {
-		return fmt.Errorf("subB.Subscribe: %w", err)
-	}
-	subBsub.OnClose = func(topic string) {
-		fmt.Printf("  [OnClose] subBsub closing topic=%q\n", topic)
-	}
-
-	fmt.Println("\n=== 5. subB.Subscribe(alerts, Block, 400ms timeout) ===")
-	fmt.Printf("  subBsub.Ch cap=%d (Block=0 means unbuffered)\n", cap(subBsub.Ch))
-	fmt.Printf("  subBsub.ErrCh==nil? %v (timeout set => non-nil)\n", subBsub.ErrCh == nil)
-
-	// === Phase 6: 起 4 个 drain goroutine 各自消费一条 sub ============
-	// 收尾时通过 done channel 等齐。subA 三个 drain 等 Ch 关闭；
-	// subBsub 的 drain 同时监听 Ch + ErrCh（任一边关闭即退出）。
-	fmt.Println("\n=== 6. Drain goroutines (4× spawned) ===")
-	dones := []<-chan struct{}{
-		drainSubscription("subA:metrics", subsA[0], nil),
-		drainSubscription("subA:audit", subsA[1], nil),
-		drainSubscription("subA:alerts", subsA[2], nil),
-		drainSubscription("subB:alerts", subBsub, subBsub.ErrCh),
-	}
-	fmt.Println("  4 drainers running; will be joined in Phase 12")
-
-	// === Phase 7: Publish 突发流量 ====================================
-	fmt.Println("\n=== 7. Publish burst ===")
-	for i := 0; i < 5; i++ {
-		_ = pubA.Publish("metrics", fmt.Sprintf("m=%d", i))
-		_ = pubA.Publish("audit", fmt.Sprintf("a=%d", i))
-		_ = pubB.Publish("alerts", fmt.Sprintf("alert=%d", i))
-	}
-	fmt.Println("  15 messages dispatched (5 per topic × 3 topics)")
-
-	// === Phase 8: 容量错误（tiny broker，cap=2）=========================
-	fmt.Println("\n=== 8. ErrSubscriptionCapacityExceeded (tiny broker, cap=2) ===")
-	pubT := pubsub.NewPublisher[string](tinyBroker)
-	subT := pubsub.NewSubscriber[string](tinyBroker)
-	if err := pubT.Publish("t1", "x"); err != nil {
-		return fmt.Errorf("Publish t1 should succeed: %w", err)
-	}
-	fmt.Println("  Publish(t1)    -> ok (1/2)")
-	if err := pubT.Publish("t2", "x"); err != nil {
-		return fmt.Errorf("Publish t2 should succeed: %w", err)
-	}
-	fmt.Println("  Publish(t2)    -> ok (2/2)")
-	_, err = subT.Subscribe("t3")
-	if !errors.Is(err, pubsub.ErrSubscriptionCapacityExceeded) {
-		return fmt.Errorf("Subscribe t3: expected ErrSubscriptionCapacityExceeded, got %v", err)
-	}
-	fmt.Println("  Subscribe(t3)  ->", err)
-
-	// === Phase 9: 等 subBsub 的滑动 timeout 自然 fire ===================
-	// 上面最后一次 publish 之后 400ms，timer 就会 fire。
-	// drain goroutine 看到 ErrSubscriptionTimeout 就会打印并退出。
-	fmt.Println("\n=== 9. Sliding timeout (subBsub, 400ms) ===")
-	time.Sleep(500 * time.Millisecond)
-
-	// === Phase 10: ErrSubscriberClosed 路径 =============================
-	// 这里分两条路：
-	//  1) subBsub.Close() -> 走 OnClose + unsubscribe（topic=alerts 退出）
-	//  2) subB.Close() 第一次 -> 所有 topic 都已经退订，no-op，nil
-	//  3) subB.Close() 第二次 -> 返回 ErrSubscriberClosed
-	//  4) subB.Subscribe(...) -> 返回 ErrSubscriberClosed
-	fmt.Println("\n=== 10. ErrSubscriberClosed ===")
-	if err := subBsub.Close(); err != nil {
-		return fmt.Errorf("subBsub.Close: %w", err)
-	}
-	if err := subB.Close(); err != nil {
-		return fmt.Errorf("first subB.Close should be a no-op, got %v", err)
-	}
-	if err := subB.Close(); !errors.Is(err, pubsub.ErrSubscriberClosed) {
-		return fmt.Errorf("second subB.Close: expected ErrSubscriberClosed, got %v", err)
-	}
-	fmt.Println("  subBsub.Close()  -> OnClose fired above")
-	fmt.Println("  subB.Close() 1st -> nil (no topics left)")
-	fmt.Println("  subB.Close() 2nd ->", pubsub.ErrSubscriberClosed)
-	if _, err := subB.Subscribe("after-close"); !errors.Is(err, pubsub.ErrSubscriberClosed) {
-		return fmt.Errorf("Subscribe after Close: expected ErrSubscriberClosed, got %v", err)
-	}
-	fmt.Println("  subB.Subscribe()  ->", pubsub.ErrSubscriberClosed)
-
-	// === Phase 11: 逐个关 subA 的 sub，触发 OnClose × 3 ================
-	// Subscriber.Close 不会触发 OnClose（设计上 OnClose 只挂在
-	// Subscription.Close 上），所以要拿到 3 个 OnClose 回调只能
-	// 显式 sub.Close() 三个。
-	fmt.Println("\n=== 11. OnClose × 3 (subA's subscriptions) ===")
-	for _, s := range subsA {
-		if err := s.Close(); err != nil {
-			return fmt.Errorf("subA sub.Close: %w", err)
-		}
-	}
-	// 三个 topic 都已退订，subA.Close() 这里是 no-op。再次调一次
-	// 演示 Subscriber.Close 也走 ErrSubscriberClosed 这条路。
-	if err := subA.Close(); err != nil {
-		return fmt.Errorf("subA.Close (after per-sub close) should be no-op, got %v", err)
-	}
-	if err := subA.Close(); !errors.Is(err, pubsub.ErrSubscriberClosed) {
-		return fmt.Errorf("second subA.Close: expected ErrSubscriberClosed, got %v", err)
-	}
-
-	// === Phase 12: 等所有 drain goroutine 退出 =========================
-	fmt.Println("\n=== 12. Drain summary ===")
-	for _, done := range dones {
-		<-done
-	}
-	fmt.Println("  all drainers exited")
-
-	// === Phase 13: 退出前 introspect broker ============================
-	// 异步 topic reaping：topic 最后一个订阅者退订后，broker 在独立
-	// goroutine 里才回收，所以 Topics() 看到的可能是 0~3 的中间态。
-	// 最坏情况：3 个 topic 都还在（reaping 还没跑）；最好情况：0
-	// （reaping 跑得比 Close 完还快）。实测通常落在 0~1。
-	fmt.Println("\n=== 13. Broker.Topics() at exit ===")
-	topics := mainBroker.Topics()
-	fmt.Printf("  %d topic(s) still tracked: %v\n", len(topics), topics)
-
-	fmt.Println("\nquickstart: ok")
-	return nil
-}
-
-// drainSubscription 消费一条 *Subscription 直到 Ch 关闭，或者
-// errCh 给出错误（subBsub 走 timeout 路径会触发此分支）。
-// 返回的 channel 在 drain 退出时关闭，让调用方能 join。
-func drainSubscription[T any](label string, sub *pubsub.Subscription[T], errCh <-chan error) <-chan struct{} {
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		if errCh == nil {
-			// 没传 ErrCh：单纯排空 Ch。subA 的 3 个 sub 走这条。
-			// 静默排空到 sub.Ch 关闭；输出让 phase 7 那种 burst 自证。
-			for range sub.Ch {
-				_ = struct{}{}
-			}
-			return
-		}
-		// 同时监听 Ch + ErrCh，任一边关闭 / 给出错误即退出。
-		for {
-			select {
-			case _, ok := <-sub.Ch:
-				if !ok {
-					return
-				}
-			case err, ok := <-errCh:
-				if !ok {
-					return
-				}
-				if errors.Is(err, pubsub.ErrSubscriptionTimeout) {
-					fmt.Printf("  [timeout] %s: %v\n", label, err)
-					return
-				}
-				fmt.Printf("  [error]   %s: %v\n", label, err)
-				return
-			}
-		}
-	}()
-	return done
 }


### PR DESCRIPTION
## Why

README's Quick Start is a 45-line inline snippet, but the runnable
program in `cmd/quickstart` had been growing into a 13-phase
~260-line end-to-end walk-through. The two pieces drift
independently:

- README was using outdated ceremony (panic instead of log.Fatal,
  IIFE-wrapped defer Close, a 5-second WithTimeout that could
  never fire in a happy-path run, a `// Output: "..."` comment
  that's a godoc convention that doesn't apply to `cmd/`
  binaries).
- The program had been refined to cover every exported symbol in
  a single `go run` and to demonstrate the documented API
  contract on its own.

The fix: give each piece a single, clear job.

## What this PR does

### New `cmd/quickstart` (73 lines)

A minimum viable example that mirrors README's Quick Start 1:1.
One broker, one publisher, one subscriber, one topic, one Publish,
one Receive. Synchronous Publish means the 200 ms `WithTimeout`
demonstrably resets on the happy path (the `select` hits the `Ch`
branch, never the `ErrCh` one).

```bash
go run ./cmd/quickstart
# → Received: CPU over 90%!
```

### `cmd/quickstart-e2e` (renamed, content unchanged)

The 13-phase end-to-end walk-through that previously lived at
`cmd/quickstart/main.go`. Same surface, same phase numbering, same
output. Only the trailing `"quickstart: ok"` was renamed to
`"quickstart-e2e: ok"` to match the new binary name.

```bash
go run ./cmd/quickstart-e2e
# → 30-line transcript ending in "quickstart-e2e: ok"
```

### Docs

- README's Quick Start is rewritten to be 1:1 with the new
  simplified binary.
- `cmd/quickstart/README.md` is rewritten to describe the
  minimal binary and point at `cmd/quickstart-e2e/README.md` for
  the longer walk-through.
- `cmd/quickstart-e2e/README.md` is the previous contents of
  `cmd/quickstart/README.md` with internal references updated to
  the new path.
- `CHANGELOG.md` adds a `### Changed (examples split)` section
  summarising the move.

## What's not in this PR

- **No library code changes.** All `pubsub/` code is identical to
  `main`. The existing unit tests in `pubsub/` remain the contract.
- **No CI changes.** The existing `.github/workflows/test.yml` is
  the contract; both `cmd/quickstart/main.go` and
  `cmd/quickstart-e2e/main.go` already pass `gofmt -l`,
  `go vet ./...`, and `go test -race -count=1 ./...`.

## Verified locally

```
$ go run ./cmd/quickstart
Received: CPU over 90%!

$ go run ./cmd/quickstart-e2e
... (30-line transcript) ...
quickstart-e2e: ok

$ go build ./...               ok
$ go vet ./...                 clean
$ gofmt -l $(git ls-files)     clean
$ go test -race -count=1 ./... 3.1s, green
```